### PR TITLE
WC Network parameter fix

### DIFF
--- a/frontend/src/components/Loader.tsx
+++ b/frontend/src/components/Loader.tsx
@@ -9,19 +9,22 @@ import { StakingAppClient } from '../services/StakingAppClient';
 interface LoaderParams {
     network: string;
     userAddress: string;
+    stakingNetwork?:string
 }
 
 interface LoaderDispatch {
-    onLoad: (network: string, userAddress: string, contractAddress: string) => Promise<void>;
+    onLoad: (network: string, userAddress: string, contractAddress: string,stakingNetwork?: string) => Promise<void>;
 }
 
 function mapStateToProps(state: RootState): LoaderParams {
     const userProfile = state.data.userData?.profile;
+    const stakingData = state.data.stakingData.selectedContract;
     const addr = userProfile?.accountGroups[0]?.addresses || {};
     const address = addr[0] || {};
     return {
-        network: address.network,
+        network: stakingData?.network || address.network,
         userAddress: address.address,
+        stakingNetwork: stakingData?.network
     };
 }
 
@@ -44,12 +47,12 @@ const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) => ({
 
 function Loader(params: LoaderParams&LoaderDispatch) {
     const { contractAddress } = useParams<{contractAddress: string}>();
-    const { network, userAddress, onLoad } = params;
+    const { network, userAddress, onLoad, stakingNetwork } = params;
     useEffect(() => {
         if (contractAddress) {
-            onLoad(network, userAddress, contractAddress);
+            onLoad(network, userAddress, contractAddress,stakingNetwork);
         }
-    }, [contractAddress, network, userAddress, onLoad]);
+    }, [contractAddress, network, userAddress, onLoad,stakingNetwork]);
     return (
         <>
         </>


### PR DESCRIPTION
**What does this PR**
- This fixes the issue with the parameter being passed on connecting to a staking contract from a different network,
it adds an additional parameter to get the connecting contract network from the staking data when available.
- it also adds the staking contract network parameter to props to ensure UI rebuilds once it becomes available.